### PR TITLE
test: standardize assertion methods to use unittest consistently

### DIFF
--- a/tests/test_devices.py
+++ b/tests/test_devices.py
@@ -122,11 +122,11 @@ class TestDeviceTools(unittest.TestCase):
 
         # Verify result
         parsed = json.loads(result)
-        assert parsed["success"] is True
-        assert parsed["message"] == "Device retrieved successfully"
-        assert parsed["data"]["name"] == "test-device"
-        assert parsed["data"]["id"] == "device-123"
-        assert parsed["data"]["device_type"] == "Router"
+        self.assertTrue(parsed["success"])
+        self.assertEqual(parsed["message"], "Device retrieved successfully")
+        self.assertEqual(parsed["data"]["name"], "test-device")
+        self.assertEqual(parsed["data"]["id"], "device-123")
+        self.assertEqual(parsed["data"]["device_type"], "Router")
 
         # Verify client was called correctly with depth parameter
         self.mock_client.dcim.devices.get.assert_called_with(id="device-123", depth=1)
@@ -143,15 +143,15 @@ class TestDeviceTools(unittest.TestCase):
 
         # Verify result
         parsed = json.loads(result)
-        assert parsed["success"] is True
-        assert parsed["message"] == "Device retrieved successfully"
-        assert parsed["data"]["name"] == "test-device"
+        self.assertTrue(parsed["success"])
+        self.assertEqual(parsed["message"], "Device retrieved successfully")
+        self.assertEqual(parsed["data"]["name"], "test-device")
 
         # Verify both calls were made with depth parameter
         calls = self.mock_client.dcim.devices.get.call_args_list
-        assert len(calls) == 2
-        assert calls[0][1] == {"id": "test-device", "depth": 1}
-        assert calls[1][1] == {"name": "test-device", "depth": 1}
+        self.assertEqual(len(calls), 2)
+        self.assertEqual(calls[0][1], {"id": "test-device", "depth": 1})
+        self.assertEqual(calls[1][1], {"name": "test-device", "depth": 1})
 
     def test_get_device_not_found(self):
         """Test device not found scenario."""
@@ -164,8 +164,8 @@ class TestDeviceTools(unittest.TestCase):
 
         # Verify error response
         parsed = json.loads(result)
-        assert "error" in parsed
-        assert "Device not found" in parsed["error"]
+        self.assertIn("error", parsed)
+        self.assertIn("Device not found", parsed["error"])
 
     def test_create_device_success(self):
         """Test successful device creation."""
@@ -179,9 +179,9 @@ class TestDeviceTools(unittest.TestCase):
 
         # Verify result
         parsed = json.loads(result)
-        assert parsed["success"] is True
-        assert parsed["data"]["name"] == "test-device"
-        assert "created successfully" in parsed["message"]
+        self.assertTrue(parsed["success"])
+        self.assertEqual(parsed["data"]["name"], "test-device")
+        self.assertIn("created successfully", parsed["message"])
 
         # Verify device creation was called with correct parameters
         self.mock_client.dcim.devices.create.assert_called_once_with(
@@ -209,7 +209,7 @@ class TestDeviceTools(unittest.TestCase):
 
         # Verify error response
         parsed = json.loads(result)
-        assert "error" in parsed
+        self.assertIn("error", parsed)
 
     def test_update_device_success(self):
         """Test successful device update."""
@@ -226,13 +226,13 @@ class TestDeviceTools(unittest.TestCase):
 
         # Verify result
         parsed = json.loads(result)
-        assert parsed["success"] is True
-        assert parsed["data"]["name"] == "test-device"
-        assert "status" in parsed["data"]["updated_fields"]
-        assert "comments" in parsed["data"]["updated_fields"]
+        self.assertTrue(parsed["success"])
+        self.assertEqual(parsed["data"]["name"], "test-device")
+        self.assertIn("status", parsed["data"]["updated_fields"])
+        self.assertIn("comments", parsed["data"]["updated_fields"])
 
         # Verify device was saved
-        assert hasattr(self.mock_device, "update")
+        self.assertTrue(hasattr(self.mock_device, "update"))
 
     def test_delete_device_success(self):
         """Test successful device deletion."""
@@ -243,9 +243,9 @@ class TestDeviceTools(unittest.TestCase):
 
         # Verify result
         parsed = json.loads(result)
-        assert parsed["success"] is True
-        assert parsed["data"]["deleted"] == "test-device"
-        assert "deleted successfully" in parsed["message"]
+        self.assertTrue(parsed["success"])
+        self.assertEqual(parsed["data"]["deleted"], "test-device")
+        self.assertIn("deleted successfully", parsed["message"])
 
     def test_delete_device_not_found(self):
         """Test device deletion when device not found."""
@@ -258,5 +258,5 @@ class TestDeviceTools(unittest.TestCase):
 
         # Verify error response
         parsed = json.loads(result)
-        assert "error" in parsed
-        assert "Device not found" in parsed["error"]
+        self.assertIn("error", parsed)
+        self.assertIn("Device not found", parsed["error"])

--- a/tests/test_jobs.py
+++ b/tests/test_jobs.py
@@ -65,10 +65,10 @@ class TestJobTools(unittest.TestCase):
 
         # Verify result
         parsed = json.loads(result)
-        assert len(parsed) == 2
-        assert parsed[0]["name"] == "test-job"
-        assert parsed[0]["id"] == "job-123"
-        assert parsed[1]["name"] == "another-job"
+        self.assertEqual(len(parsed), 2)
+        self.assertEqual(parsed[0]["name"], "test-job")
+        self.assertEqual(parsed[0]["id"], "job-123")
+        self.assertEqual(parsed[1]["name"], "another-job")
 
         # Verify client was called correctly
         self.mock_client.extras.jobs.filter.assert_called_once_with(limit=20)
@@ -83,8 +83,8 @@ class TestJobTools(unittest.TestCase):
 
         # Verify error response
         parsed = json.loads(result)
-        assert "error" in parsed
-        assert "API Error" in parsed["error"]
+        self.assertIn("error", parsed)
+        self.assertIn("API Error", parsed["error"])
         self.mock_context.error.assert_called_once()
 
     def test_get_job_success(self):
@@ -96,9 +96,9 @@ class TestJobTools(unittest.TestCase):
 
         # Verify result
         parsed = json.loads(result)
-        assert parsed["name"] == "test-job"
-        assert parsed["id"] == "job-123"
-        assert parsed["slug"] == "test-job"
+        self.assertEqual(parsed["name"], "test-job")
+        self.assertEqual(parsed["id"], "job-123")
+        self.assertEqual(parsed["slug"], "test-job")
 
         # Verify client was called correctly
         self.mock_client.extras.jobs.get.assert_called_with("job-123")
@@ -113,8 +113,8 @@ class TestJobTools(unittest.TestCase):
 
         # Verify error response
         parsed = json.loads(result)
-        assert "error" in parsed
-        assert "Job not found" in parsed["error"]
+        self.assertIn("error", parsed)
+        self.assertIn("Job not found", parsed["error"])
 
     def test_run_job_success(self):
         """Test successful job execution."""
@@ -125,9 +125,9 @@ class TestJobTools(unittest.TestCase):
 
         # Verify result
         parsed = json.loads(result)
-        assert parsed["success"] is True
-        assert parsed["data"]["job_name"] == "test-job"
-        assert "started successfully" in parsed["message"]
+        self.assertTrue(parsed["success"])
+        self.assertEqual(parsed["data"]["job_name"], "test-job")
+        self.assertIn("started successfully", parsed["message"])
 
     def test_run_job_not_found(self):
         """Test running non-existent job."""
@@ -139,8 +139,8 @@ class TestJobTools(unittest.TestCase):
 
         # Verify error response
         parsed = json.loads(result)
-        assert "error" in parsed
-        assert "Job not found" in parsed["error"]
+        self.assertIn("error", parsed)
+        self.assertIn("Job not found", parsed["error"])
 
     def test_list_job_results_success(self):
         """Test successful job result listing."""
@@ -161,10 +161,10 @@ class TestJobTools(unittest.TestCase):
 
         # Verify result
         parsed = json.loads(result)
-        assert len(parsed) == 2
-        assert parsed[0]["name"] == "test-result"
-        assert parsed[0]["id"] == "result-123"
-        assert parsed[1]["name"] == "another-result"
+        self.assertEqual(len(parsed), 2)
+        self.assertEqual(parsed[0]["name"], "test-result")
+        self.assertEqual(parsed[0]["id"], "result-123")
+        self.assertEqual(parsed[1]["name"], "another-result")
 
         # Verify client was called correctly
         self.mock_client.extras.job_results.filter.assert_called_once_with(limit=10)
@@ -184,7 +184,7 @@ class TestJobTools(unittest.TestCase):
 
         # Verify empty result
         parsed = json.loads(result)
-        assert parsed == []
+        self.assertEqual(parsed, [])
 
     def test_get_job_result_success(self):
         """Test successful job result retrieval."""
@@ -195,9 +195,9 @@ class TestJobTools(unittest.TestCase):
 
         # Verify result
         parsed = json.loads(result)
-        assert parsed["name"] == "test-result"
-        assert parsed["id"] == "result-123"
-        assert parsed["status"] == "Success"
+        self.assertEqual(parsed["name"], "test-result")
+        self.assertEqual(parsed["id"], "result-123")
+        self.assertEqual(parsed["status"], "Success")
 
         # Verify client was called correctly
         self.mock_client.extras.job_results.get.assert_called_with(id="result-123")
@@ -214,7 +214,7 @@ class TestJobTools(unittest.TestCase):
 
         # Verify error response
         parsed = json.loads(result)
-        assert "error" in parsed
+        self.assertIn("error", parsed)
 
     def test_get_job_logs_success(self):
         """Test successful job log retrieval."""
@@ -225,9 +225,9 @@ class TestJobTools(unittest.TestCase):
 
         # Verify result
         parsed = json.loads(result)
-        assert parsed["success"] is True
-        assert parsed["data"]["job_result_id"] == "result-123"
-        assert parsed["data"]["logs"] == "Job execution log content"
+        self.assertTrue(parsed["success"])
+        self.assertEqual(parsed["data"]["job_result_id"], "result-123")
+        self.assertEqual(parsed["data"]["logs"], "Job execution log content")
 
         # Verify client was called correctly
         self.mock_client.extras.job_results.get.assert_called_with(id="result-123")
@@ -244,4 +244,4 @@ class TestJobTools(unittest.TestCase):
 
         # Verify error response
         parsed = json.loads(result)
-        assert "error" in parsed
+        self.assertIn("error", parsed)

--- a/tests/test_locations.py
+++ b/tests/test_locations.py
@@ -67,10 +67,10 @@ class TestLocationTools(unittest.TestCase):
 
         # Verify result
         parsed = json.loads(result)
-        assert len(parsed) == 2
-        assert parsed[0]["name"] == "test-location"
-        assert parsed[0]["id"] == "location-123"
-        assert parsed[1]["name"] == "test-location-2"
+        self.assertEqual(len(parsed), 2)
+        self.assertEqual(parsed[0]["name"], "test-location")
+        self.assertEqual(parsed[0]["id"], "location-123")
+        self.assertEqual(parsed[1]["name"], "test-location-2")
 
         # Verify client was called correctly with depth and offset parameters
         self.mock_client.dcim.locations.filter.assert_called_once_with(depth=1, limit=10, offset=None)
@@ -90,7 +90,7 @@ class TestLocationTools(unittest.TestCase):
 
         # Verify empty result
         parsed = json.loads(result)
-        assert parsed == []
+        self.assertEqual(parsed, [])
 
     def test_list_locations_exception(self):
         """Test location listing with exception."""
@@ -101,8 +101,8 @@ class TestLocationTools(unittest.TestCase):
 
         # Verify error response
         parsed = json.loads(result)
-        assert "error" in parsed
-        assert "API Error" in parsed["error"]
+        self.assertIn("error", parsed)
+        self.assertIn("API Error", parsed["error"])
         self.mock_context.error.assert_called_once()
 
     def test_get_location_success(self):
@@ -114,9 +114,9 @@ class TestLocationTools(unittest.TestCase):
 
         # Verify result
         parsed = json.loads(result)
-        assert parsed["data"]["name"] == "test-location"
-        assert parsed["data"]["id"] == "location-123"
-        assert parsed["data"]["location_type"] == "Site"
+        self.assertEqual(parsed["data"]["name"], "test-location")
+        self.assertEqual(parsed["data"]["id"], "location-123")
+        self.assertEqual(parsed["data"]["location_type"], "Site")
 
         # Verify client was called correctly with depth parameter
         self.mock_client.dcim.locations.get.assert_called_with(id="location-123", depth=1)
@@ -132,8 +132,8 @@ class TestLocationTools(unittest.TestCase):
 
         # Verify error response
         parsed = json.loads(result)
-        assert "error" in parsed
-        assert "Location not found" in parsed["error"]
+        self.assertIn("error", parsed)
+        self.assertIn("Location not found", parsed["error"])
 
     def test_create_location_success(self):
         """Test successful location creation."""
@@ -152,15 +152,15 @@ class TestLocationTools(unittest.TestCase):
 
         # Verify result
         parsed = json.loads(result)
-        assert parsed["success"] is True
-        assert parsed["data"]["name"] == "test-location"
-        assert "created successfully" in parsed["message"]
+        self.assertTrue(parsed["success"])
+        self.assertEqual(parsed["data"]["name"], "test-location")
+        self.assertIn("created successfully", parsed["message"])
 
         # Verify lookups were performed - first ID, then name
         calls = self.mock_client.dcim.location_types.get.call_args_list
-        assert len(calls) == 2
-        assert calls[0][1] == {"id": "Site"}
-        assert calls[1][1] == {"name": "Site"}
+        self.assertEqual(len(calls), 2)
+        self.assertEqual(calls[0][1], {"id": "Site"})
+        self.assertEqual(calls[1][1], {"name": "Site"})
         self.mock_client.extras.statuses.get.assert_called_once_with(name="active")
 
     def test_create_location_missing_location_type(self):
@@ -172,8 +172,8 @@ class TestLocationTools(unittest.TestCase):
 
         # Verify error response
         parsed = json.loads(result)
-        assert "error" in parsed
-        assert "Location type not found" in parsed["error"]
+        self.assertIn("error", parsed)
+        self.assertIn("Location type not found", parsed["error"])
 
     def test_update_location_success(self):
         """Test successful location update."""
@@ -190,13 +190,13 @@ class TestLocationTools(unittest.TestCase):
 
         # Verify result
         parsed = json.loads(result)
-        assert parsed["success"] is True
-        assert parsed["data"]["name"] == "test-location"
-        assert "status" in parsed["data"]["updated_fields"]
-        assert "description" in parsed["data"]["updated_fields"]
+        self.assertTrue(parsed["success"])
+        self.assertEqual(parsed["data"]["name"], "test-location")
+        self.assertIn("status", parsed["data"]["updated_fields"])
+        self.assertIn("description", parsed["data"]["updated_fields"])
 
         # Verify location was saved
-        assert hasattr(self.mock_location, "update")
+        self.assertTrue(hasattr(self.mock_location, "update"))
 
     def test_delete_location_success(self):
         """Test successful location deletion."""
@@ -207,9 +207,9 @@ class TestLocationTools(unittest.TestCase):
 
         # Verify result
         parsed = json.loads(result)
-        assert parsed["success"] is True
-        assert parsed["data"]["deleted"] == "test-location"
-        assert "deleted successfully" in parsed["message"]
+        self.assertTrue(parsed["success"])
+        self.assertEqual(parsed["data"]["deleted"], "test-location")
+        self.assertIn("deleted successfully", parsed["message"])
 
     def test_delete_location_not_found(self):
         """Test location deletion when location not found."""
@@ -222,5 +222,5 @@ class TestLocationTools(unittest.TestCase):
 
         # Verify error response
         parsed = json.loads(result)
-        assert "error" in parsed
-        assert "Location not found" in parsed["error"]
+        self.assertIn("error", parsed)
+        self.assertIn("Location not found", parsed["error"])


### PR DESCRIPTION
### What
- Standardized all test assertion methods to use unittest's `self.assert*()` methods consistently
- Converted 60+ assertion statements across test files

### Why
- Ensures consistent test reporting and better error messages
- Follows unittest best practices for assertion methods
- Improves test maintainability and debugging experience

### How
- Replaced `assert condition` with `self.assertTrue(condition)`
- Replaced `assert a == b` with `self.assertEqual(a, b)` 
- Replaced `assert "text" in string` with `self.assertIn("text", string)`
- Updated assertions in `test_devices.py`, `test_locations.py`, and `test_jobs.py`
- All 45 tests continue to pass after changes

### Proof
- ✅ All 45 tests pass with consistent unittest assertion methods
- ✅ No remaining Python `assert` statements in test files
- ✅ Linting passes with standardized code style