### PR TITLE
feat: add GraphQL tool and tests

### DIFF
--- a/nautobot_mcp_server/tools/__init__.py
+++ b/nautobot_mcp_server/tools/__init__.py
@@ -1,10 +1,11 @@
 """Tools package for Nautobot MCP Server."""
 
 from .devices import DeviceTools
+from .graphql import GraphQLTools
 from .jobs import JobTools
 from .locations import LocationTools
 
-__all__ = ["DeviceTools", "LocationTools", "JobTools", "register_all_tools"]
+__all__ = ["DeviceTools", "GraphQLTools", "LocationTools", "JobTools", "register_all_tools"]
 
 
 def register_all_tools(mcp, client_getter):
@@ -16,10 +17,12 @@ def register_all_tools(mcp, client_getter):
     """
     # Initialize tool classes
     device_tools = DeviceTools(client_getter)
+    graphql_tools = GraphQLTools(client_getter)
     location_tools = LocationTools(client_getter)
     job_tools = JobTools(client_getter)
 
     # Register all tools
     device_tools.register(mcp)
+    graphql_tools.register(mcp)
     location_tools.register(mcp)
     job_tools.register(mcp)

--- a/nautobot_mcp_server/tools/graphql.py
+++ b/nautobot_mcp_server/tools/graphql.py
@@ -1,0 +1,45 @@
+"""GraphQL-related tools for Nautobot MCP Server."""
+
+from mcp.server.fastmcp import Context, FastMCP
+from pynautobot import RequestError
+
+from .base import NautobotToolBase
+
+
+class GraphQLTools(NautobotToolBase):
+    """Tools for the graphql endpoint in Nautobot."""
+
+    def register(self, mcp: FastMCP):
+        """Register graphql tools with the MCP server.
+
+        Args:
+            mcp: FastMCP instance to register tools with
+        """
+
+        @mcp.tool()
+        def nautobot_graphql_query(ctx: Context, query: str, variables: dict | None = None) -> str:
+            """
+            Get results from Nautobot GraphQL query.
+
+            Args:
+                ctx: MCP context for logging and progress
+                query: GraphQL query string to execute
+                variables: Optional dictionary of variables for the query
+
+            Returns:
+                JSON string of GraphQL results
+            """
+            ctx.info(f"Running GraphQL query: {query}, variables: {variables}")
+
+            try:
+                client = self._get_client()
+                response = client.graphql.query(query=query, variables=variables)
+
+                ctx.info("Successfully retrieved graphql results")
+                return self.format_success(response.json, message="Results retrieved successfully")
+            except RequestError as e:
+                ctx.warning(f"RequestError: {e}")
+                return self.format_error(f"Error retrieving GraphQL results: {e}")
+
+            except Exception as e:
+                return self.log_and_return_error(ctx, "getting GraphQL results", e)

--- a/tests/test_graphql.py
+++ b/tests/test_graphql.py
@@ -1,0 +1,213 @@
+"""Tests for GraphQL tools."""
+
+import json
+import unittest
+from unittest.mock import MagicMock
+
+from pynautobot import RequestError
+
+from nautobot_mcp_server.tools.graphql import GraphQLTools
+
+
+class TestGraphQLTools(unittest.TestCase):
+    """Test GraphQL functionality."""
+
+    def setUp(self):
+        """Set up test fixtures using simple mocks."""
+        # Create mock client
+        self.mock_client = MagicMock()
+
+        # Create mock GraphQL client
+        self.mock_graphql_client = MagicMock()
+        self.mock_client.graphql = self.mock_graphql_client
+
+        # Create mock context
+        self.mock_context = MagicMock()
+
+        # Create GraphQL tools instance
+        self.graphql_tools = GraphQLTools(lambda: self.mock_client)
+
+        # Sample GraphQL response data
+        self.sample_graphql_response = {
+            "data": {
+                "devices": [
+                    {
+                        "id": "device-123",
+                        "name": "test-device",
+                        "deviceType": {"name": "Router"},
+                        "location": {"name": "DC-01"},
+                    },
+                    {
+                        "id": "device-456",
+                        "name": "test-device-2",
+                        "deviceType": {"name": "Switch"},
+                        "location": {"name": "DC-02"},
+                    },
+                ]
+            }
+        }
+
+    def _register_and_get_function(self, function_index):
+        """Helper to register tools and get function."""
+        mcp_mock = MagicMock()
+        tool_decorator_mock = MagicMock()
+        mcp_mock.tool.return_value = tool_decorator_mock
+
+        self.graphql_tools.register(mcp_mock)
+
+        return tool_decorator_mock.call_args_list[function_index][0][0]
+
+    def test_graphql_query_success(self):
+        """Test successful GraphQL query execution."""
+        # Mock GraphQL response
+        mock_response = MagicMock()
+        mock_response.json = self.sample_graphql_response
+        self.mock_graphql_client.query.return_value = mock_response
+
+        graphql_query_func = self._register_and_get_function(0)
+
+        query = """
+        query {
+            devices {
+                id
+                name
+                deviceType {
+                    name
+                }
+                location {
+                    name
+                }
+            }
+        }
+        """
+
+        result = graphql_query_func(self.mock_context, query)
+
+        # Verify result
+        parsed = json.loads(result)
+        self.assertTrue(parsed["success"])
+        self.assertEqual(parsed["message"], "Results retrieved successfully")
+        self.assertEqual(parsed["data"], self.sample_graphql_response)
+
+        # Verify GraphQL client was called correctly
+        self.mock_graphql_client.query.assert_called_once_with(query=query, variables=None)
+        self.mock_context.info.assert_called()
+
+    def test_graphql_query_with_variables_success(self):
+        """Test successful GraphQL query execution with variables."""
+        # Mock GraphQL response
+        mock_response = MagicMock()
+        mock_response.json = self.sample_graphql_response
+        self.mock_graphql_client.query.return_value = mock_response
+
+        graphql_query_func = self._register_and_get_function(0)
+
+        query = """
+        query GetDevicesByLocation($locationName: String!) {
+            devices(location: $locationName) {
+                id
+                name
+                deviceType {
+                    name
+                }
+            }
+        }
+        """
+        variables = {"locationName": "DC-01"}
+
+        result = graphql_query_func(self.mock_context, query, variables)
+
+        # Verify result
+        parsed = json.loads(result)
+        self.assertTrue(parsed["success"])
+        self.assertEqual(parsed["message"], "Results retrieved successfully")
+        self.assertEqual(parsed["data"], self.sample_graphql_response)
+
+        # Verify GraphQL client was called correctly with variables
+        self.mock_graphql_client.query.assert_called_once_with(query=query, variables=variables)
+        self.mock_context.info.assert_called()
+
+    def test_graphql_query_request_error(self):
+        """Test GraphQL query with RequestError."""
+        mock_request = MagicMock()
+        mock_request.status_code = 400
+        self.mock_graphql_client.query.side_effect = RequestError(mock_request)
+
+        graphql_query_func = self._register_and_get_function(0)
+
+        query = "query { invalid_field }"
+
+        result = graphql_query_func(self.mock_context, query)
+
+        # Verify error response
+        parsed = json.loads(result)
+        self.assertIn("error", parsed)
+        self.assertIn("Error retrieving GraphQL results", parsed["error"])
+        self.mock_context.warning.assert_called_once()
+
+    def test_graphql_query_generic_exception(self):
+        """Test GraphQL query with generic exception."""
+        self.mock_graphql_client.query.side_effect = Exception("Network error")
+
+        graphql_query_func = self._register_and_get_function(0)
+
+        query = "query { devices { id name } }"
+
+        result = graphql_query_func(self.mock_context, query)
+
+        # Verify error response
+        parsed = json.loads(result)
+        self.assertIn("error", parsed)
+        self.assertIn("Network error", parsed["error"])
+        self.mock_context.error.assert_called_once()
+
+    def test_graphql_query_empty_response(self):
+        """Test GraphQL query with empty response."""
+        # Mock empty GraphQL response
+        mock_response = MagicMock()
+        mock_response.json = {"data": {}}
+        self.mock_graphql_client.query.return_value = mock_response
+
+        graphql_query_func = self._register_and_get_function(0)
+
+        query = "query { devices { id } }"
+
+        result = graphql_query_func(self.mock_context, query)
+
+        # Verify result
+        parsed = json.loads(result)
+        self.assertTrue(parsed["success"])
+        self.assertEqual(parsed["message"], "Results retrieved successfully")
+        self.assertEqual(parsed["data"], {"data": {}})
+
+        # Verify GraphQL client was called correctly
+        self.mock_graphql_client.query.assert_called_once_with(query=query, variables=None)
+
+    def test_graphql_query_complex_variables(self):
+        """Test GraphQL query with complex variables structure."""
+        # Mock GraphQL response
+        mock_response = MagicMock()
+        mock_response.json = self.sample_graphql_response
+        self.mock_graphql_client.query.return_value = mock_response
+
+        graphql_query_func = self._register_and_get_function(0)
+
+        query = """
+        query FilterDevices($filters: DeviceFiltersInput, $limit: Int) {
+            devices(filters: $filters, limit: $limit) {
+                id
+                name
+            }
+        }
+        """
+        variables = {"filters": {"location": "DC-01", "status": "active"}, "limit": 10}
+
+        result = graphql_query_func(self.mock_context, query, variables)
+
+        # Verify result
+        parsed = json.loads(result)
+        self.assertTrue(parsed["success"])
+        self.assertEqual(parsed["data"], self.sample_graphql_response)
+
+        # Verify GraphQL client was called correctly with complex variables
+        self.mock_graphql_client.query.assert_called_once_with(query=query, variables=variables)


### PR DESCRIPTION
### What
- Add `GraphQLTools` class with `nautobot_graphql_query` tool for executing Nautobot GraphQL queries
- Add comprehensive test suite in `test_graphql.py` following existing patterns

### Why
- Enable AI agents to perform complex Nautobot queries using GraphQL for advanced data retrieval
- Support optional variables for parameterized queries

### How
- Implement `GraphQLTools` inheriting from `NautobotToolBase` for consistent error handling
- Use `pynautobot.graphql.query()` method for query execution
- Add 6 test cases covering success scenarios, error handling, and edge cases
- Follow existing test patterns with `MockRecord` and `_register_and_get_function()` helper

### Proof
All tests pass (51/51) including new GraphQL tests

<img width="413" height="726" alt="Screenshot 2025-08-11 at 1 41 36 AM" src="https://github.com/user-attachments/assets/8f9ab86a-5eda-40ab-b0fd-f369033fd95f" />

.

<img width="545" height="624" alt="Screenshot 2025-08-11 at 2 00 50 AM" src="https://github.com/user-attachments/assets/1af05342-6442-4441-a906-f2eae19454f9" />

.

<img width="539" height="645" alt="Screenshot 2025-08-11 at 2 04 47 AM" src="https://github.com/user-attachments/assets/6010a8db-934b-4446-ab98-22277c5ae776" />

