### PR TITLE
refactor: simplify update methods and add MCP resources for field schemas

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,9 +47,10 @@ export NAUTOBOT_TOKEN=your-api-token
 
 ### Available Tools
 
-The MCP server currently supports CRUD and get/list operations for:
- - Devices
- - Locations
+The MCP server currently supports
+ - `GraphQL` queries
+ - `dcim.devices` CRUD ops
+ - `dcim.locations` CRUD ops
 
 It also supports the following operations for Nautobot Jobs:
  - `get_job`

--- a/nautobot_mcp_server/resources/__init__.py
+++ b/nautobot_mcp_server/resources/__init__.py
@@ -1,0 +1,28 @@
+"""Resources module for Nautobot MCP Server."""
+
+from mcp.server.fastmcp import FastMCP
+
+from .devices import DeviceSchemaResource
+from .locations import LocationSchemaResource
+
+
+def register_all_resources(mcp: FastMCP):
+    """Register all resources with the MCP server.
+
+    Args:
+        mcp: FastMCP instance to register resources with
+    """
+    resources = [
+        DeviceSchemaResource(),
+        LocationSchemaResource(),
+    ]
+
+    for resource in resources:
+        resource.register(mcp)
+
+
+__all__ = [
+    "register_all_resources",
+    "DeviceSchemaResource",
+    "LocationSchemaResource",
+]

--- a/nautobot_mcp_server/resources/base.py
+++ b/nautobot_mcp_server/resources/base.py
@@ -1,0 +1,32 @@
+"""Base class for Nautobot MCP resources."""
+
+import json
+from typing import Any
+
+import yaml
+
+
+class NautobotResourceBase:
+    """Base class for Nautobot resource implementations."""
+
+    def format_yaml(self, data: Any) -> str:
+        """Format data as YAML string.
+
+        Args:
+            data: Data to format
+
+        Returns:
+            YAML-formatted string
+        """
+        return yaml.dump(data, default_flow_style=False, sort_keys=False, allow_unicode=True, indent=2)
+
+    def format_json(self, data: Any) -> str:
+        """Format data as JSON string.
+
+        Args:
+            data: Data to format
+
+        Returns:
+            JSON-formatted string
+        """
+        return json.dumps(data, indent=2, ensure_ascii=False)

--- a/nautobot_mcp_server/resources/devices.py
+++ b/nautobot_mcp_server/resources/devices.py
@@ -1,0 +1,90 @@
+"""Device schema resources for Nautobot MCP Server."""
+
+from mcp.server.fastmcp import FastMCP
+
+from .base import NautobotResourceBase
+
+
+class DeviceSchemaResource(NautobotResourceBase):
+    """Resources for exposing device schemas to AI agents."""
+
+    # Device field definitions - optimized for token efficiency
+    DEVICE_FIELDS = {
+        "name": {"type": "string", "required_for_create": True},
+        "device_type": {"type": "string", "required_for_create": True},
+        "location": {"type": "string", "required_for_create": True},
+        "role": {"type": "string", "required_for_create": True},
+        "status": {"type": "string", "required_for_create": True},
+        "asset_tag": {"type": "string"},
+        "cluster": {"type": "string"},
+        "comments": {"type": "string"},
+        "custom_fields": {"type": "dict"},
+        "device_redundancy_group": {"type": "string"},
+        "device_redundancy_group_priority": {"type": "integer"},
+        "face": {"type": "string", "choices": ["Front", "Rear"]},
+        "parent_bay": {"type": "string"},
+        "platform": {"type": "string"},
+        "position": {"type": "integer"},
+        "primary_ip4": {"type": "string"},
+        "primary_ip6": {"type": "string"},
+        "rack": {"type": "string"},
+        "relationships": {"type": "dict"},
+        "serial": {"type": "string"},
+        "secrets_group": {"type": "string"},
+        "software_image_files": {"type": "list"},
+        "software_version": {"type": "string"},
+        "tags": {"type": "list"},
+        "tenant": {"type": "string"},
+        "vc_position": {"type": "integer"},
+        "vc_priority": {"type": "integer"},
+        "virtual_chassis": {"type": "string"},
+    }
+
+    def register(self, mcp: FastMCP):
+        """Register device schema resources with the MCP server.
+
+        Args:
+            mcp: FastMCP instance to register resources with
+        """
+
+        @mcp.resource("schema://device/fields")
+        def get_device_fields() -> str:
+            """Get all available device fields with their types and descriptions.
+
+            Returns a YAML string describing all device fields that can be used
+            in create and update operations.
+            """
+            return self.format_yaml(self.DEVICE_FIELDS)
+
+        @mcp.resource("schema://device/required-for-create")
+        def get_device_required_fields() -> str:
+            """Get required device fields for CREATE operations only.
+
+            Returns a YAML list of field names that are required when creating a device.
+            Note: Updates do not require any specific fields.
+            """
+            required_fields = [
+                name for name, spec in self.DEVICE_FIELDS.items() if spec.get("required_for_create", False)
+            ]
+            data = {
+                "required_for_create": required_fields,
+                "note": "These fields are ONLY required when creating a new device. Updates can modify any subset of fields.",
+            }
+            return self.format_yaml(data)
+
+        @mcp.resource("schema://device/examples")
+        def get_device_examples() -> str:
+            """Device operation examples."""
+            examples = {
+                "create": {
+                    "name": "switch01",
+                    "device_type": "Catalyst",
+                    "location": "dc1",
+                    "role": "access",
+                    "status": "active",
+                },
+                "update_single": {"status": "maintenance"},
+                "update_multi": {"location": "dc2", "rack": "R05", "position": 10},
+                "update_clear_fields": {"asset_tag": None, "serial": None},
+            }
+            return self.format_yaml(examples)

--- a/nautobot_mcp_server/resources/locations.py
+++ b/nautobot_mcp_server/resources/locations.py
@@ -1,0 +1,80 @@
+"""Location schema resources for Nautobot MCP Server."""
+
+from mcp.server.fastmcp import FastMCP
+
+from .base import NautobotResourceBase
+
+
+class LocationSchemaResource(NautobotResourceBase):
+    """Resources for exposing location schemas to AI agents."""
+
+    # Location field definitions - optimized for token efficiency
+    LOCATION_FIELDS = {
+        "name": {"type": "string", "required_for_create": True},
+        "location_type": {"type": "string", "required_for_create": True},
+        "status": {"type": "string", "required_for_create": False, "default": "active"},
+        "parent": {"type": "string"},
+        "description": {"type": "string"},
+        "facility": {"type": "string"},
+        "asn": {"type": "integer"},
+        "time_zone": {"type": "string"},
+        "physical_address": {"type": "string"},
+        "shipping_address": {"type": "string"},
+        "latitude": {"type": "string"},
+        "longitude": {"type": "string"},
+        "contact_name": {"type": "string"},
+        "contact_phone": {"type": "string"},
+        "contact_email": {"type": "string"},
+    }
+
+    def register(self, mcp: FastMCP):
+        """Register location schema resources with the MCP server.
+
+        Args:
+            mcp: FastMCP instance to register resources with
+        """
+
+        @mcp.resource("schema://location/fields")
+        def get_location_fields() -> str:
+            """Get all available location fields with their types and descriptions.
+
+            Returns a YAML string describing all location fields that can be used
+            in create and update operations.
+            """
+            return self.format_yaml(self.LOCATION_FIELDS)
+
+        @mcp.resource("schema://location/required-for-create")
+        def get_location_required_fields() -> str:
+            """Get required location fields for CREATE operations only.
+
+            Returns a YAML list of field names that are required when creating a location.
+            Note: Updates do not require any specific fields.
+            """
+            required_fields = [
+                name for name, spec in self.LOCATION_FIELDS.items() if spec.get("required_for_create", False)
+            ]
+            data = {
+                "required_for_create": required_fields,
+                "note": "These fields are ONLY required when creating a new location. Updates can modify any subset of fields.",
+            }
+            return self.format_yaml(data)
+
+        @mcp.resource("schema://location/examples")
+        def get_location_examples() -> str:
+            """Location operation examples."""
+            examples = {
+                "create": {
+                    "name": "datacenter-01",
+                    "location_type": "datacenter",
+                    "status": "active",
+                    "facility": "DC01",
+                },
+                "update_single": {"status": "maintenance"},
+                "update_multi": {
+                    "description": "Updated datacenter",
+                    "facility": "DC01-NEW",
+                    "contact_name": "Jane Doe",
+                },
+                "update_clear_fields": {"contact_phone": None, "contact_email": None},
+            }
+            return self.format_yaml(examples)

--- a/nautobot_mcp_server/server.py
+++ b/nautobot_mcp_server/server.py
@@ -5,6 +5,7 @@ from typing import Optional
 import pynautobot
 from mcp.server.fastmcp import FastMCP
 
+from .resources import register_all_resources
 from .tools import register_all_tools
 
 
@@ -25,6 +26,9 @@ class NautobotMCPServer:
 
         # Register all tools from the tools submodule
         register_all_tools(self.mcp, self._get_client)
+
+        # Register all resources from the resources submodule
+        register_all_resources(self.mcp)
 
     def _get_client(self) -> pynautobot.api:
         """Get or create Nautobot client."""

--- a/poetry.lock
+++ b/poetry.lock
@@ -2567,7 +2567,7 @@ version = "6.0.2"
 description = "YAML parser and emitter for Python"
 optional = false
 python-versions = ">=3.8"
-groups = ["dev"]
+groups = ["main", "dev"]
 files = [
     {file = "PyYAML-6.0.2-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:0a9a2848a5b7feac301353437eb7d5957887edbf81d56e903999a75a3d743086"},
     {file = "PyYAML-6.0.2-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:29717114e51c84ddfba879543fb232a6ed60086602313ca38cce623c1d62cfbf"},
@@ -3255,4 +3255,4 @@ all = []
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.11,<3.13"
-content-hash = "4d9685fa9f5250f93a867e950adeef818ec53e99a8a8ca2b889fda09a82fb0d4"
+content-hash = "5df18ff16ad9db81f9312672205d9c865acc4a7357fb3c9dd02cf16344535ff6"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,7 @@ package-mode = false
 python = ">=3.11,<3.13"
 mcp-server = ">=0.1.4,<0.2.0"
 pynautobot = "^2.2.1"
+pyyaml = "^6.0.1"
 
 [tool.poetry.group.dev.dependencies]
 ruff = "^0.12.8"

--- a/test_mcp_client.py
+++ b/test_mcp_client.py
@@ -30,6 +30,13 @@ async def test_nautobot_mcp():
             print("MCP Server initialized successfully!")
             print("=" * 50)
 
+            # List available resources
+            resources = await session.list_resources()
+            print("Available resources:")
+            for resource in resources:
+                print(f"  - {repr(resource)}")
+            print("=" * 50)
+
             # List available tools
             tools = await session.list_tools()
             print("Available tools:")
@@ -79,6 +86,18 @@ async def test_nautobot_mcp():
             # for content in result:
             #     if hasattr(content, 'text'):
             #         print(content.text)
+
+            print("\nTest 2: Listing device resource")
+            result = await session.read_resource("schema://device/fields")
+            print("Response:")
+            for content in result:
+                # if hasattr(content, "text"):
+                #     try:
+                #         data = json.loads(content.text)
+                #         print(json.dumps(data, indent=2))
+                #     except json.JSONDecodeError:
+                #         print(content.text)
+                print(repr(content))
 
             print("\n" + "=" * 50)
             print("Test completed successfully!")


### PR DESCRIPTION
### What
- Simplified device and location update methods to accept a single `updates` dict parameter
- Added new MCP resources for exposing field schemas to AI agents

### Why
- AI agents need access to field definitions and examples to construct proper update requests
- In the update methods, need to be able to differentiate between an intentional `null` vs an ignored field while still conveying the necessary parameters to agents.

### How
- Refactored `nautobot_update_device` and `nautobot_update_location` to accept `updates: dict[str, Any]`
- Created new `resources/` module with `DeviceSchemaResource` and `LocationSchemaResource`
- Added MCP resources: `schema://device/fields`, `schema://device/required-for-create`, `schema://device/examples`
- Added corresponding location schema resources
- Updated all tests to match new update method signatures
- Added PyYAML dependency for resource formatting, which is a more token-efficient format than JSON

### Proof
- All tests pass with new update method signatures
- MCP resources provide comprehensive field documentation for AI agents
- Simplified API reduces complexity while maintaining full functionality

##### Device Create (agent consults new schema for required fields 🎉 )
<img width="424" height="457" alt="Screenshot 2025-08-11 at 1 36 56 PM" src="https://github.com/user-attachments/assets/cc76867c-b6ed-44d4-89d4-53e9e15b39ae" />

##### Device Update
<img width="500" alt="Screenshot 2025-08-11 at 1 25 58 PM" src="https://github.com/user-attachments/assets/d05d6084-70a2-4097-98af-3cf8c917981a" />

##### Location Update (failed successfully)

<img width="500" alt="Screenshot 2025-08-11 at 1 27 49 PM" src="https://github.com/user-attachments/assets/cc1df0cd-7089-4231-8ae2-dc57d4bf8d03" />
<img width="500" alt="Screenshot 2025-08-11 at 1 27 57 PM" src="https://github.com/user-attachments/assets/394dae9d-b44c-4ee8-a1f5-01eb565c58ff" />

