### PR TITLE
feat: compact json to reduce token size

### DIFF
--- a/nautobot_mcp_server/resources/base.py
+++ b/nautobot_mcp_server/resources/base.py
@@ -9,7 +9,8 @@ import yaml
 class NautobotResourceBase:
     """Base class for Nautobot resource implementations."""
 
-    def format_yaml(self, data: Any) -> str:
+    @staticmethod
+    def format_yaml(data: Any) -> str:
         """Format data as YAML string.
 
         Args:
@@ -20,7 +21,8 @@ class NautobotResourceBase:
         """
         return yaml.dump(data, default_flow_style=False, sort_keys=False, allow_unicode=True, indent=2)
 
-    def format_json(self, data: Any) -> str:
+    @staticmethod
+    def format_json(data: Any) -> str:
         """Format data as JSON string.
 
         Args:
@@ -29,4 +31,4 @@ class NautobotResourceBase:
         Returns:
             JSON-formatted string
         """
-        return json.dumps(data, indent=2, ensure_ascii=False)
+        return json.dumps(data, ensure_ascii=False, separators=(",", ":"))

--- a/nautobot_mcp_server/resources/devices.py
+++ b/nautobot_mcp_server/resources/devices.py
@@ -54,7 +54,7 @@ class DeviceSchemaResource(NautobotResourceBase):
             Returns a YAML string describing all device fields that can be used
             in create and update operations.
             """
-            return self.format_yaml(self.DEVICE_FIELDS)
+            return self.format_json(self.DEVICE_FIELDS)
 
         @mcp.resource("schema://device/required-for-create")
         def get_device_required_fields() -> str:
@@ -70,7 +70,7 @@ class DeviceSchemaResource(NautobotResourceBase):
                 "required_for_create": required_fields,
                 "note": "These fields are ONLY required when creating a new device. Updates can modify any subset of fields.",
             }
-            return self.format_yaml(data)
+            return self.format_json(data)
 
         @mcp.resource("schema://device/examples")
         def get_device_examples() -> str:
@@ -87,4 +87,4 @@ class DeviceSchemaResource(NautobotResourceBase):
                 "update_multi": {"location": "dc2", "rack": "R05", "position": 10},
                 "update_clear_fields": {"asset_tag": None, "serial": None},
             }
-            return self.format_yaml(examples)
+            return self.format_json(examples)

--- a/nautobot_mcp_server/resources/locations.py
+++ b/nautobot_mcp_server/resources/locations.py
@@ -41,7 +41,7 @@ class LocationSchemaResource(NautobotResourceBase):
             Returns a YAML string describing all location fields that can be used
             in create and update operations.
             """
-            return self.format_yaml(self.LOCATION_FIELDS)
+            return self.format_json(self.LOCATION_FIELDS)
 
         @mcp.resource("schema://location/required-for-create")
         def get_location_required_fields() -> str:
@@ -57,7 +57,7 @@ class LocationSchemaResource(NautobotResourceBase):
                 "required_for_create": required_fields,
                 "note": "These fields are ONLY required when creating a new location. Updates can modify any subset of fields.",
             }
-            return self.format_yaml(data)
+            return self.format_json(data)
 
         @mcp.resource("schema://location/examples")
         def get_location_examples() -> str:
@@ -77,4 +77,4 @@ class LocationSchemaResource(NautobotResourceBase):
                 },
                 "update_clear_fields": {"contact_phone": None, "contact_email": None},
             }
-            return self.format_yaml(examples)
+            return self.format_json(examples)

--- a/nautobot_mcp_server/tools/base.py
+++ b/nautobot_mcp_server/tools/base.py
@@ -27,7 +27,7 @@ class NautobotToolBase:
         Returns:
             JSON formatted error string
         """
-        return json.dumps({"error": error_msg})
+        return json.dumps({"error": error_msg}, separators=(",", ":"))
 
     @staticmethod
     def format_success(data: Any, message: Optional[str] = None) -> str:
@@ -41,8 +41,8 @@ class NautobotToolBase:
             JSON formatted success response
         """
         if message:
-            return json.dumps({"success": True, "message": message, "data": data}, indent=2)
-        return json.dumps(data, indent=2)
+            return json.dumps({"success": True, "message": message, "data": data}, separators=(",", ":"))
+        return json.dumps(data, separators=(",", ":"))
 
     def log_and_return_error(self, ctx: Context, operation: str, error: Exception) -> str:
         """Log an error and return formatted error response.

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -22,7 +22,7 @@ class TestNautobotToolBase(unittest.TestCase):
         error_msg = "Test error message"
         result = NautobotToolBase.format_error(error_msg)
 
-        expected = json.dumps({"error": error_msg})
+        expected = json.dumps({"error": error_msg}, separators=(",", ":"))
         self.assertEqual(result, expected)
 
         # Verify it's valid JSON
@@ -36,7 +36,7 @@ class TestNautobotToolBase(unittest.TestCase):
 
         result = NautobotToolBase.format_success(data, message)
 
-        expected = json.dumps({"success": True, "message": message, "data": data}, indent=2)
+        expected = json.dumps({"success": True, "message": message, "data": data}, separators=(",", ":"))
         self.assertEqual(result, expected)
 
         # Verify it's valid JSON
@@ -51,7 +51,7 @@ class TestNautobotToolBase(unittest.TestCase):
 
         result = NautobotToolBase.format_success(data)
 
-        expected = json.dumps(data, indent=2)
+        expected = json.dumps(data, separators=(",", ":"))
         self.assertEqual(result, expected)
 
         # Verify it's valid JSON
@@ -64,7 +64,7 @@ class TestNautobotToolBase(unittest.TestCase):
 
         result = NautobotToolBase.format_success(data)
 
-        expected = json.dumps(data, indent=2)
+        expected = json.dumps(data, separators=(",", ":"))
         self.assertEqual(result, expected)
 
         # Verify it's valid JSON
@@ -87,7 +87,7 @@ class TestNautobotToolBase(unittest.TestCase):
 
         # Verify correct error response format
         expected_error_msg = f"Error {operation}: {str(error)}"
-        expected = json.dumps({"error": expected_error_msg})
+        expected = json.dumps({"error": expected_error_msg}, separators=(",", ":"))
         self.assertEqual(result, expected)
 
     def test_log_and_return_error_with_complex_exception(self):
@@ -97,7 +97,7 @@ class TestNautobotToolBase(unittest.TestCase):
         mock_context = Mock()
 
         operation = "complex operation"
-        error = ValueError("Complex error with special chars: !@#$%^&*()")
+        error = ValueError("Complex error with special chars:!@#$%^&*()")
 
         result = tool.log_and_return_error(mock_context, operation, error)
 


### PR DESCRIPTION
### What
 - compact serialized JSON strings to reduce token count

### Why
 - Nautobot API responses are large and token size limits in MCP tools (e.g., 25k by default in claude code) is a concern

### How
 - set json separators to eliminate whitespace

### Proof

Same JSON response of 5 devices before and after (7k vs 2k):

<img width="783" height="477" alt="Screenshot 2025-08-12 at 11 12 21 PM" src="https://github.com/user-attachments/assets/ed0c574d-d256-4759-ad95-d212c4b8dd21" />

.

<img width="798" height="488" alt="Screenshot 2025-08-12 at 11 12 28 PM" src="https://github.com/user-attachments/assets/13a8c58d-fb46-4f6b-a011-4a17ae9ec635" />

.


<img width="466" height="527" alt="Screenshot 2025-08-12 at 11 15 55 PM" src="https://github.com/user-attachments/assets/d7641d6f-22fd-41c6-bc90-face6232c89b" />
